### PR TITLE
Add Stickynote Uploader 5001 React app

### DIFF
--- a/stickynote-uploader-5001/package.json
+++ b/stickynote-uploader-5001/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "stickynote-uploader-5001",
+  "version": "0.1.0",
+  "private": true,
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-scripts": "5.0.1",
+    "react-router-dom": "^6.14.1"
+  },
+  "scripts": {
+    "start": "react-scripts start",
+    "build": "react-scripts build",
+    "test": "react-scripts test --env=jsdom",
+    "eject": "react-scripts eject"
+  }
+}

--- a/stickynote-uploader-5001/public/index.html
+++ b/stickynote-uploader-5001/public/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Stickynote Uploader 5001</title>
+  </head>
+  <body>
+    <div id="root"></div>
+  </body>
+</html>

--- a/stickynote-uploader-5001/src/App.css
+++ b/stickynote-uploader-5001/src/App.css
@@ -1,0 +1,14 @@
+.App header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1rem;
+}
+
+.logo {
+  font-weight: bold;
+}
+
+button {
+  cursor: pointer;
+}

--- a/stickynote-uploader-5001/src/App.js
+++ b/stickynote-uploader-5001/src/App.js
@@ -1,0 +1,71 @@
+import React, { useState, useEffect, createContext, useContext } from 'react';
+import { Routes, Route, Link, useNavigate } from 'react-router-dom';
+import StickyUpload from './components/StickyUpload';
+import Carousel from './components/Carousel';
+import StickyList from './components/StickyList';
+import StickyBlog from './components/StickyBlog';
+import ThemeToggle from './components/ThemeToggle';
+import './App.css';
+
+export const ThemeContext = createContext();
+export const NotesContext = createContext();
+
+const EDIT_ENABLED = true; // simulate backend flag
+
+export default function App() {
+  const [theme, setTheme] = useState(() => localStorage.getItem('theme') || 'light');
+  const [notes, setNotes] = useState(() => {
+    const saved = localStorage.getItem('notes');
+    return saved ? JSON.parse(saved) : [];
+  });
+  const [uploadDisabled, setUploadDisabled] = useState(false);
+
+  useEffect(() => {
+    document.body.className = theme;
+    localStorage.setItem('theme', theme);
+  }, [theme]);
+
+  useEffect(() => {
+    localStorage.setItem('notes', JSON.stringify(notes));
+  }, [notes]);
+
+  const toggleTheme = () => setTheme(t => (t === 'light' ? 'dark' : 'light'));
+
+  const addNote = note => setNotes(n => [note, ...n]);
+  const updateNote = updated =>
+    setNotes(n => n.map(note => (note.id === updated.id ? updated : note)));
+
+  const likeNote = id => {
+    setNotes(n => n.map(note => (note.id === id ? { ...note, liked: true } : note)));
+    setUploadDisabled(true);
+  };
+
+  return (
+    <ThemeContext.Provider value={{ theme, toggleTheme }}>
+      <NotesContext.Provider value={{ notes, addNote, updateNote, likeNote, uploadDisabled, EDIT_ENABLED }}>
+        <div className="App">
+          <header>
+            <Link to="/" className="logo">StickyNote Uploader 5001</Link>
+            <ThemeToggle />
+          </header>
+          <Routes>
+            <Route path="/" element={<Home />} />
+            <Route path="/note/:id" element={<StickyBlog />} />
+          </Routes>
+        </div>
+      </NotesContext.Provider>
+    </ThemeContext.Provider>
+  );
+}
+
+function Home() {
+  const { EDIT_ENABLED, uploadDisabled } = useContext(NotesContext);
+  const navigate = useNavigate();
+  return (
+    <div>
+      <Carousel />
+      {EDIT_ENABLED && !uploadDisabled && <StickyUpload />}
+      <StickyList />
+    </div>
+  );
+}

--- a/stickynote-uploader-5001/src/components/Carousel.css
+++ b/stickynote-uploader-5001/src/components/Carousel.css
@@ -1,0 +1,24 @@
+.carousel {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 1rem;
+  margin: 1rem;
+}
+
+.carousel-image {
+  position: relative;
+}
+
+.carousel-image img {
+  width: 200px;
+  height: 200px;
+  object-fit: cover;
+  -webkit-box-reflect: below 2px linear-gradient(transparent, rgba(0,0,0,0.2));
+  border-radius: 8px;
+  transition: transform 0.3s;
+}
+
+.carousel-image img:hover {
+  transform: scale(1.05);
+}

--- a/stickynote-uploader-5001/src/components/Carousel.js
+++ b/stickynote-uploader-5001/src/components/Carousel.js
@@ -1,0 +1,26 @@
+import React, { useContext, useState } from 'react';
+import { NotesContext } from '../App';
+import { Link } from 'react-router-dom';
+import './Carousel.css';
+
+export default function Carousel() {
+  const { notes } = useContext(NotesContext);
+  const images = notes.slice(0, 3);
+  const [index, setIndex] = useState(0);
+  if (!images.length) return null;
+
+  const prev = () => setIndex(i => (i === 0 ? images.length - 1 : i - 1));
+  const next = () => setIndex(i => (i + 1) % images.length);
+
+  return (
+    <div className="carousel">
+      <button onClick={prev} aria-label="Prev">‹</button>
+      <div className="carousel-image">
+        <Link to={`/note/${images[index].id}`}>
+          <img src={images[index].image} alt="sticky" />
+        </Link>
+      </div>
+      <button onClick={next} aria-label="Next">›</button>
+    </div>
+  );
+}

--- a/stickynote-uploader-5001/src/components/StickyBlog.css
+++ b/stickynote-uploader-5001/src/components/StickyBlog.css
@@ -1,0 +1,10 @@
+.blog {
+  padding: 1rem;
+}
+
+.blog-image {
+  width: 100%;
+  max-width: 400px;
+  height: auto;
+  border-radius: 8px;
+}

--- a/stickynote-uploader-5001/src/components/StickyBlog.js
+++ b/stickynote-uploader-5001/src/components/StickyBlog.js
@@ -1,0 +1,32 @@
+import React, { useContext, useState } from 'react';
+import "./StickyBlog.css";
+import { useParams, useNavigate } from 'react-router-dom';
+import { NotesContext } from '../App';
+import StickyUpload from './StickyUpload';
+
+export default function StickyBlog() {
+  const { id } = useParams();
+  const navigate = useNavigate();
+  const { notes, updateNote, EDIT_ENABLED, likeNote } = useContext(NotesContext);
+  const note = notes.find(n => n.id === id);
+  const [editing, setEditing] = useState(false);
+
+  if (!note) return <p>Not found</p>;
+
+  const handleLike = () => {
+    likeNote(note.id);
+    navigate('/');
+  };
+
+  return (
+    <div className="blog">
+      <img src={note.image} alt="sticky" className="blog-image" />
+      <p>{note.content}</p>
+      <button onClick={handleLike} disabled={note.liked}>Like</button>
+      {EDIT_ENABLED && (
+        <button onClick={() => setEditing(e => !e)}>{editing ? 'Cancel' : 'Edit'}</button>
+      )}
+      {editing && EDIT_ENABLED && <StickyUpload existing={note} onUpdate={updateNote} />}
+    </div>
+  );
+}

--- a/stickynote-uploader-5001/src/components/StickyList.js
+++ b/stickynote-uploader-5001/src/components/StickyList.js
@@ -1,0 +1,17 @@
+import React, { useContext } from 'react';
+import { NotesContext } from '../App';
+import { Link } from 'react-router-dom';
+
+export default function StickyList() {
+  const { notes } = useContext(NotesContext);
+  if (!notes.length) return <p>No notes yet.</p>;
+  return (
+    <ul>
+      {notes.map(note => (
+        <li key={note.id}>
+          <Link to={`/note/${note.id}`}>{note.content.slice(0, 30) || 'Untitled'}</Link>
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/stickynote-uploader-5001/src/components/StickyUpload.css
+++ b/stickynote-uploader-5001/src/components/StickyUpload.css
@@ -1,0 +1,18 @@
+.upload-form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  margin: 1rem 0;
+}
+
+.preview {
+  width: 200px;
+  height: 200px;
+  object-fit: cover;
+  align-self: start;
+  border-radius: 8px;
+}
+
+textarea {
+  min-height: 100px;
+}

--- a/stickynote-uploader-5001/src/components/StickyUpload.js
+++ b/stickynote-uploader-5001/src/components/StickyUpload.js
@@ -1,0 +1,57 @@
+import React, { useState, useContext, useEffect } from 'react';
+import "./StickyUpload.css";
+import { NotesContext } from '../App';
+
+export default function StickyUpload({ existing, onUpdate }) {
+  const { addNote } = useContext(NotesContext);
+  const [image, setImage] = useState(existing ? existing.image : null);
+  const [content, setContent] = useState(existing ? existing.content : '');
+
+  useEffect(() => {
+    if (existing) {
+      setImage(existing.image);
+      setContent(existing.content);
+    }
+  }, [existing]);
+
+  const handleImage = e => {
+    const file = e.target.files[0];
+    if (file) {
+      const reader = new FileReader();
+      reader.onload = ev => setImage(ev.target.result);
+      reader.readAsDataURL(file);
+    }
+  };
+
+  const handleSubmit = e => {
+    e.preventDefault();
+    if (!image) return;
+    if (existing && onUpdate) {
+      onUpdate({ ...existing, image, content });
+    } else {
+      const note = { id: Date.now().toString(), image, content, liked: false };
+      addNote(note);
+    }
+    setImage(null);
+    setContent('');
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="upload-form">
+      <input
+        type="file"
+        accept="image/*"
+        capture="environment"
+        onChange={handleImage}
+        aria-label="Sticky image"
+      />
+      {image && <img src={image} alt="preview" className="preview" />}
+      <textarea
+        placeholder="Your sticky note content"
+        value={content}
+        onChange={e => setContent(e.target.value)}
+      />
+      <button type="submit">{existing ? 'Save' : 'Upload'}</button>
+    </form>
+  );
+}

--- a/stickynote-uploader-5001/src/components/ThemeToggle.js
+++ b/stickynote-uploader-5001/src/components/ThemeToggle.js
@@ -1,0 +1,11 @@
+import React, { useContext } from 'react';
+import { ThemeContext } from '../App';
+
+export default function ThemeToggle() {
+  const { theme, toggleTheme } = useContext(ThemeContext);
+  return (
+    <button onClick={toggleTheme} aria-label="Toggle theme">
+      {theme === 'light' ? 'Dark' : 'Light'} Mode
+    </button>
+  );
+}

--- a/stickynote-uploader-5001/src/index.css
+++ b/stickynote-uploader-5001/src/index.css
@@ -1,0 +1,19 @@
+body {
+  margin: 0;
+  font-family: sans-serif;
+}
+
+body.light {
+  background: #f6f6f6;
+  color: #222;
+}
+
+body.dark {
+  background: #222;
+  color: #f6f6f6;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}

--- a/stickynote-uploader-5001/src/index.js
+++ b/stickynote-uploader-5001/src/index.js
@@ -1,0 +1,12 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import { BrowserRouter } from 'react-router-dom';
+import App from './App';
+import './index.css';
+
+const root = ReactDOM.createRoot(document.getElementById('root'));
+root.render(
+  <BrowserRouter>
+    <App />
+  </BrowserRouter>
+);


### PR DESCRIPTION
## Summary
- initialize React app `stickynote-uploader-5001`
- add dark/light themes and theme toggle
- implement sticky note upload with mobile camera support
- create carousel with reflection effect
- implement blog post view with optional editing and like button
- persist notes and theme in localStorage

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
